### PR TITLE
Ord1 instance for Exp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ tests/support/package-lock.json
 .psc-package/
 tags
 TAGS
+.nvimrc
 
 # Gather source map files from golden tests
 .source-maps


### PR DESCRIPTION
This also includes related instances for `Pat`, `Lit` and `BindE`, as well as fixes for missing cases in their respective `Eq1` instances.