### PR TITLE
Expr Plated instance

### DIFF
--- a/src/Language/PureScript/AST/Literals.hs
+++ b/src/Language/PureScript/AST/Literals.hs
@@ -35,7 +35,14 @@ data Literal a -- a ~ Expr Ann
     -- |
     -- An object literal
     ObjectLiteral [(PSString, a)]
-  deriving (Eq, Ord, Show, Functor, Generic)
+  deriving stock (Eq, Ord, Show, Functor, Generic, Traversable)
 
 instance (FromJSON a) => FromJSON (Literal a)
 instance (ToJSON a) => ToJSON (Literal a)
+
+instance Foldable Literal where
+  {-# INLINEABLE foldMap #-}
+  foldMap f = \case
+    ArrayLiteral lits -> foldMap f lits
+    ObjectLiteral lits -> foldMap (f . snd) lits
+    _ -> mempty

--- a/src/Language/PureScript/CoreFn/Binders.hs
+++ b/src/Language/PureScript/CoreFn/Binders.hs
@@ -11,6 +11,7 @@ import Language.PureScript.Types
 
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics
+import Control.Lens.Combinators (Plated (plate))
 
 {- |
 Data type for binders
@@ -35,6 +36,15 @@ data Binder a
 
 instance (FromJSON a) => FromJSON (Binder a)
 instance (ToJSON a) => ToJSON (Binder a)
+
+instance Plated (Binder a) where
+  {-# INLINEABLE plate #-}
+  plate f = \case
+    x@(NullBinder _) -> pure x 
+    LiteralBinder x lit -> LiteralBinder x <$> traverse f lit
+    x@(VarBinder _ _ _) -> pure x
+    ConstructorBinder x tyName conName binds -> ConstructorBinder x tyName conName <$> traverse f binds
+    NamedBinder x ident bind -> NamedBinder x ident <$> f bind
 
 extractBinderAnn :: Binder a -> a
 extractBinderAnn (NullBinder a) = a

--- a/src/Language/PureScript/CoreFn/Utils.hs
+++ b/src/Language/PureScript/CoreFn/Utils.hs
@@ -223,28 +223,4 @@ exprType = \case
   Case _ ty _ _ -> ty
   Let _ _ e -> exprType e
 
-instance Plated (Expr a) where
-  plate f = \case
-    Literal a t lit -> Literal a t <$> traverseLit f lit
-    Accessor a t s e -> Accessor a t s <$> f e
-    ObjectUpdate a t e cf fs ->
-      (\e' fs' -> ObjectUpdate a t e' cf fs')
-        <$> f e
-        <*> traverse (traverse f) fs
-    Abs a t bv e -> Abs a t bv <$> f e
-    App a e1 e2 -> App a <$> f e1 <*> f e2
-    Var a t qi -> pure $ Var a t qi
-    Case a t scruts alts ->
-      Case a t
-        <$> traverse f scruts
-        <*> traverse goAlt alts
-    Let a decls body ->
-      Let a <$> traverse goDecl decls <*> f body
-    where
-      goAlt (CaseAlternative caBinders caResult) =
-        CaseAlternative caBinders
-          <$> bitraverse (traverse (traverse f)) f caResult
 
-      goDecl = \case
-        NonRec a nm body -> NonRec a nm <$> f body
-        Rec xs -> Rec <$> traverse (traverse f) xs


### PR DESCRIPTION
This rehomes the `Plated` instance for `Expr` from `CoreFn`, as well as making some supporting changes.
