### PR TITLE
TH splice for Module CTE loads

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -410,6 +410,7 @@ library
     Language.Purus.Debug
     Language.Purus.Eval 
     Language.Purus.IR
+    Language.Purus.TH
     Language.Purus.IR.Utils
     Language.Purus.Make
     Language.Purus.Pipeline.Monad

--- a/src/Language/PureScript/PSString.hs
+++ b/src/Language/PureScript/PSString.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveLift #-}
+
 module Language.PureScript.PSString (
   PSString,
   toUTF16CodeUnits,
@@ -33,6 +35,7 @@ import GHC.Generics (Generic)
 import Numeric (showHex)
 import System.IO.Unsafe (unsafePerformIO)
 import Prelude
+import Language.Haskell.TH.Syntax (Lift)
 
 {- |
 Strings in PureScript are sequences of UTF-16 code units, which do not
@@ -49,7 +52,7 @@ strings where that would be safe (i.e. when there are no lone surrogates),
 and arrays of UTF-16 code units (integers) otherwise.
 -}
 newtype PSString = PSString {toUTF16CodeUnits :: [Word16]}
-  deriving (Eq, Ord, Semigroup, Monoid, Generic)
+  deriving (Eq, Ord, Semigroup, Monoid, Generic, Lift)
 
 instance NFData PSString
 instance Serialise PSString

--- a/src/Language/Purus/TH.hs
+++ b/src/Language/Purus/TH.hs
@@ -1,0 +1,179 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE DeriveLift #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-implicit-lift #-}
+
+module Language.Purus.TH (
+  ctDecodeModule
+  ) where
+
+import Prelude
+import Language.Haskell.TH (Exp, Q)
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (eitherDecodeFileStrict')
+import Language.PureScript.CoreFn.Module (
+  Module (Module), 
+  Datatypes (Datatypes),
+  DataDecl (DataDecl),
+  CtorDecl (CtorDecl)
+  )
+import Language.PureScript.Types (
+  Type (TUnknown,
+        TypeVar,
+        TypeLevelString,
+        TypeLevelInt,
+        TypeWildcard,
+        TypeConstructor,
+        TypeOp,
+        TypeApp,
+        KindApp,
+        ForAll,
+        ConstrainedType,
+        Skolem,
+        REmpty,
+        RCons,
+        KindedType,
+        BinaryNoParensType,
+        ParensInType),
+  Constraint (Constraint),
+  ConstraintData (PartialConstraintData),
+  WildcardData (HoleWildcard, UnnamedWildcard, IgnoredWildcard),
+  SkolemScope (SkolemScope),
+  TypeVarVisibility (TypeVarVisible, TypeVarInvisible)
+  )
+import Language.PureScript.CoreFn.Ann (Ann)
+import Language.PureScript.AST.SourcePos (
+  SourceAnn,
+  SourcePos (SourcePos),
+  SourceSpan (SourceSpan)
+  )
+import Language.PureScript.CoreFn.Expr (
+  Bind (NonRec, Rec),
+  Expr (Literal,
+        Accessor,
+        ObjectUpdate,
+        Abs,
+        App,
+        Var,
+        Case,
+        Let),
+  CaseAlternative (CaseAlternative)
+  )
+import Language.PureScript.CoreFn.FromJSON ()
+import Language.Haskell.TH.Syntax (Lift)
+import Language.PureScript.Names (
+  Qualified (Qualified),
+  Ident (Ident, GenIdent, UnusedIdent, InternalIdent),
+  InternalIdentData (RuntimeLazyFactory, Lazy),
+  QualifiedBy (BySourcePos, ByModuleName),
+  ModuleName (ModuleName),
+  ProperName (ProperName), 
+  ProperNameType (TypeName, ClassName, ConstructorName),
+  OpName (OpName), 
+  OpNameType (TypeOpName),
+  )
+import Language.PureScript.Comments (
+  Comment (LineComment, BlockComment)
+  )
+import Language.PureScript.Label (Label (Label))
+import Language.PureScript.Environment (
+  DataDeclType (Data, Newtype)
+  )
+import Language.PureScript.AST.Literals (
+  Literal (NumericLiteral,
+           StringLiteral,
+           CharLiteral,
+           BooleanLiteral,
+           ArrayLiteral,
+           ObjectLiteral
+           )
+  )
+import Language.PureScript.CoreFn.Binders (
+  Binder (NullBinder,
+          LiteralBinder,
+          VarBinder,
+          ConstructorBinder,
+          NamedBinder
+          )
+  )
+import Language.PureScript.CoreFn.Meta (
+  Meta (IsConstructor,
+        IsNewtype,
+        IsTypeClassConstructor,
+        IsForeign,
+        IsWhere,
+        IsSyntheticApp
+        ),
+  ConstructorType (ProductType, SumType)
+  )
+
+deriving stock instance Lift InternalIdentData
+
+deriving stock instance Lift Ident
+
+deriving stock instance Lift SourcePos
+
+deriving stock instance Lift ModuleName
+
+deriving stock instance Lift QualifiedBy
+
+deriving stock instance Lift a => Lift (Qualified a)
+
+deriving stock instance Lift (ProperName 'TypeName)
+
+deriving stock instance Lift (OpName 'TypeOpName)
+
+deriving stock instance Lift (ProperName 'ClassName)
+
+deriving stock instance Lift ConstraintData
+
+deriving stock instance Lift SourceSpan
+
+deriving stock instance Lift Comment
+
+deriving stock instance Lift (Constraint SourceAnn)
+
+deriving stock instance Lift WildcardData
+
+deriving stock instance Lift SkolemScope
+
+deriving stock instance Lift TypeVarVisibility
+
+deriving stock instance Lift Label
+
+deriving stock instance Lift (Type SourceAnn)
+
+deriving stock instance Lift (CtorDecl (Type SourceAnn))
+
+deriving stock instance Lift DataDeclType
+
+deriving stock instance Lift (DataDecl (Type SourceAnn) (Type SourceAnn))
+
+deriving stock instance Lift (Datatypes (Type SourceAnn) (Type SourceAnn))
+
+deriving stock instance Lift a => Lift (Literal a)
+
+deriving stock instance Lift (ProperName 'ConstructorName)
+
+deriving stock instance Lift ConstructorType
+
+deriving stock instance Lift Meta
+
+deriving stock instance Lift (Binder Ann)
+
+deriving stock instance Lift (CaseAlternative Ann)
+
+deriving stock instance Lift (Expr Ann)
+
+deriving stock instance Lift (Bind Ann)
+
+deriving stock instance Lift (Module (Bind Ann) (Type SourceAnn) (Type SourceAnn) Ann)
+
+ctDecodeModule :: FilePath -> Q Exp
+ctDecodeModule fp = do
+  decoded <- liftIO $ eitherDecodeFileStrict' @(Module (Bind Ann) (Type SourceAnn) (Type SourceAnn) Ann) fp
+  case decoded of 
+    Left err -> fail $ "Cannot construct a Module from " <> fp <> "\nReason: " <> err
+    Right res -> [| res |]


### PR DESCRIPTION
This adds a TH based compile-time `Module` loader. This also needs a lot of (currently orphan) `Lift` instances, which could be moved to their respective modules later.