### PR TITLE
Remove tracing from Purus modules

### DIFF
--- a/src/Language/Purus/Make.hs
+++ b/src/Language/Purus/Make.hs
@@ -78,7 +78,6 @@ import System.FilePath.Glob qualified as Glob
 
 import PlutusCore.Evaluation.Result (EvaluationResult)
 
--- import Debug.Trace (traceM)
 -- import PlutusIR.Core.Instance.Pretty.Readable (prettyPirReadable)
 
 {-  Compiles a main function to PIR, given its module name, dependencies, and a
@@ -113,7 +112,6 @@ compile primModule orderedModules mainModuleName mainFunctionName =
     go = do
       (summedModule, dsCxt) <- runDesugarCore $ desugarCoreModules primModule orderedModules
       let
-        -- traceBracket lbl msg = traceM ("\n" <> lbl <> "\n\n" <> msg <> "\n\n")
         decls = moduleDecls summedModule
         declIdentsSet = foldBinds (\acc nm _ -> S.insert nm acc) S.empty decls
         couldn'tFindMain n =
@@ -126,25 +124,15 @@ compile primModule orderedModules mainModuleName mainFunctionName =
             <> "\nin declarations:\n"
             <> prettyStr (S.toList declIdentsSet)
       mainFunctionIx <- note (couldn'tFindMain 1) $ dsCxt ^? globalScope . at mainModuleName . folded . at mainFunctionName . folded
-      -- traceM $ "Found main function Index: " <> show mainFunctionIx
       mainFunctionBody <- note (couldn'tFindMain 2) $ findDeclBodyWithIndex mainFunctionName mainFunctionIx decls
-      -- traceM "Found main function body"
       inlined <- runInline summedModule $ lift (mainFunctionName, mainFunctionIx) mainFunctionBody >>= inline
-      -- traceBracket "Done inlining. Result:" $ prettyStr inlined
       let !instantiated = applyPolyRowArgs $ instantiateTypes inlined
-      -- traceBracket "Done instantiating types. Result:" $ prettyStr instantiated
       withoutObjects <- instantiateTypes <$> runCounter (desugarObjects instantiated)
-      -- traceBracket  "Desugared objects. Result:\n" $ prettyStr withoutObjects
       datatypes <- runCounter $ desugarObjectsInDatatypes (moduleDataTypes summedModule)
-      -- traceM "Desugared datatypes"
       runPlutusContext initDatatypeDict $ do
         generateDatatypes datatypes
-        -- traceM "Generated PIR datatypes"
         withoutCases <- eliminateCases datatypes withoutObjects
-        -- traceM "Eliminated case expressions. Compiling to PIR..."
         compileToPIR datatypes withoutCases
-
--- traceM . docString $ prettyPirReadable pirTerm
 
 modulesInDependencyOrder :: [[FilePath]] -> IO [Module (Bind Ann) PurusType PurusType Ann]
 modulesInDependencyOrder (concat -> paths) = do

--- a/src/Language/Purus/Pipeline/CompileToPIR.hs
+++ b/src/Language/Purus/Pipeline/CompileToPIR.hs
@@ -24,7 +24,6 @@ import Language.PureScript.CoreFn.FromJSON ()
 import Language.PureScript.CoreFn.Module (
   Datatypes,
  )
-import Language.PureScript.CoreFn.TypeLike (TypeLike (..))
 import Language.PureScript.Names (
   Ident (..),
   Qualified (..),
@@ -33,7 +32,6 @@ import Language.PureScript.Names (
  )
 import Language.PureScript.PSString (prettyPrintString)
 
-import Language.Purus.Debug (doTraceM, prettify)
 import Language.Purus.IR (
   BVar (..),
   BindE (..),
@@ -41,8 +39,7 @@ import Language.Purus.IR (
   FVar (..),
   Lit (CharL, IntL, StringL),
   Ty,
-  expTy,
-  expTy',
+  expTy
  )
 import Language.Purus.IR qualified as IR
 import Language.Purus.IR.Utils (Vars, WithoutObjects, toExp)
@@ -85,12 +82,6 @@ compileToPIR _datatypes _exp = do
   resBody <- compileToPIR' _datatypes _exp
   datatypes <- view pirDatatypes
   let binds = NE.fromList $ map (PIR.DatatypeBind ()) . M.elems $ datatypes
-      msg =
-        prettify
-          [ "INPUT:\n" <> prettyStr _exp
-          , "OUTPUT (BODY):\n" <> prettyStr resBody
-          ]
-  doTraceM "compileToPIR" msg
   pure $ PIR.Let () PIR.Rec binds resBody
 
 compileToPIR' ::
@@ -98,7 +89,7 @@ compileToPIR' ::
   Exp WithoutObjects Ty (Vars Ty) ->
   PlutusContext PIRTerm
 compileToPIR' datatypes _exp =
-  doTraceM "compileToPIR'" (prettyStr _exp) >> case _exp of
+  case _exp of
     V x -> case x of
       F Unit -> pure $ mkConstant () ()
       F (FVar _ ident@(Qualified _ (runIdent -> nm))) ->
@@ -117,24 +108,12 @@ compileToPIR' datatypes _exp =
                     <> "report this bug to the Purus authors. "
       B (BVar bvix _ (runIdent -> nm)) -> pure $ PIR.Var () (Name nm $ Unique bvix)
     LitE _ lit -> compileToPIRLit lit
-    lam@(LamE (BVar bvIx bvT bvNm) body) -> do
-      let lty = funTy bvT (expTy' id body)
+    (LamE (BVar bvIx bvT bvNm) body) -> do
       ty' <- toPIRType bvT
       let nm = Name (runIdent bvNm) $ Unique bvIx
           body' = toExp body
       body'' <- compileToPIR' datatypes body'
-      let result = PIR.LamAbs () nm ty' body''
-          msg =
-            "BVar:\n"
-              <> prettyStr bvNm
-              <> "\n\nInput Lam:\n"
-              <> prettyStr lam
-              <> "\n\nInferred Lam Ty:\n"
-              <> prettyStr lty
-              <> "\n\nRESULT: "
-              <> prettyStr result
-      doTraceM "compileToPIRLamTy" msg
-      pure result
+      pure $ PIR.LamAbs () nm ty' body''
     AppE e1 e2 -> do
       e1' <- compileToPIR' datatypes e1
       e2' <- compileToPIR' datatypes e2

--- a/src/Language/Purus/Pipeline/GenerateDatatypes/Utils.hs
+++ b/src/Language/Purus/Pipeline/GenerateDatatypes/Utils.hs
@@ -24,7 +24,6 @@ import Data.Text (Text)
 import Data.Text qualified as T
 
 import Control.Monad.State (gets, modify)
-import Debug.Trace (traceM)
 
 import Language.PureScript.CoreFn.TypeLike
 import Language.PureScript.Names (
@@ -38,7 +37,6 @@ import Language.PureScript.Names (
   showQualified,
  )
 
-import Language.Purus.Debug (doTraceM)
 import Language.Purus.IR (
   Ty (..),
  )
@@ -86,7 +84,7 @@ pseudoRandomChar i = fst $ randomR ('a', 'z') (mkStdGen i)
 
 mkTyName :: Qualified (ProperName 'TypeName) -> PlutusContext PIR.TyName
 mkTyName qn =
-  doTraceM "mkTyName" (prettyQPN qn) >> gets (view tyNames) >>= \tnames -> case M.lookup qn tnames of
+  gets (view tyNames) >>= \tnames -> case M.lookup qn tnames of
     Just tyname -> pure tyname
     Nothing -> do
       uniq <- next
@@ -96,7 +94,7 @@ mkTyName qn =
 
 mkConstrName :: Qualified Ident -> Int -> PlutusContext PIR.Name
 mkConstrName qi cix =
-  doTraceM "mkConstrName" (prettyQI qi) >> gets (view constrNames) >>= \cnames -> case M.lookup qi cnames of
+  gets (view constrNames) >>= \cnames -> case M.lookup qi cnames of
     Just cname -> pure $ fst cname
     Nothing -> do
       uniq <- next
@@ -107,7 +105,7 @@ mkConstrName qi cix =
 -- | Only gives you a TyName, doesn't insert anything into the context
 mkNewTyVar :: Text -> PlutusContext TyName
 mkNewTyVar nm =
-  doTraceM "mkNewTyVar" (T.unpack nm) >> do
+  do
     uniq <- next
     pure . PIR.TyName $ PIR.Name nm $ PLC.Unique uniq
 
@@ -120,7 +118,7 @@ freshName = do
 
 getBoundTyVarName :: Text -> PlutusContext PIR.TyName
 getBoundTyVarName nm =
-  doTraceM "mkBoundTyVarName" (T.unpack nm) >> do
+  do
     boundTyVars <- gets _tyVars
     case M.lookup nm boundTyVars of
       Just tyName -> pure tyName
@@ -145,9 +143,8 @@ getDestructorTy qn = do
 
 getConstructorName :: Qualified Ident -> PlutusContext (Maybe PLC.Name)
 getConstructorName qi =
-  doTraceM "getConstructorName" (show qi) >> do
+  do
     ctors <- gets (view constrNames)
-    traceM $ show ctors
     pure $ ctors ^? at qi . folded . _1
 
 prettyQPN :: Qualified (ProperName 'TypeName) -> String

--- a/src/Language/Purus/Utils.hs
+++ b/src/Language/Purus/Utils.hs
@@ -17,7 +17,6 @@ import Language.PureScript.Names (
   pattern ByNullSourcePos,
  )
 
-import Language.Purus.Debug (doTrace)
 import Language.Purus.IR (BVar, BindE (..), Exp)
 import Language.Purus.IR.Utils (IR_Decl, Vars, WithObjects, foldBinds, toExp)
 
@@ -60,7 +59,7 @@ findMain ::
   Text ->
   Module IR_Decl k PurusType Ann ->
   Maybe ((Ident, Int), Scope (BVar PurusType) (Exp WithObjects PurusType) (Vars PurusType))
-findMain nm Module {..} = doTrace "findDeclBody" ("NAME: " <> T.unpack nm) $ findMain' (Ident nm) moduleDecls
+findMain nm Module {..} = findMain' (Ident nm) moduleDecls
 
 findMain' ::
   forall x ty.


### PR DESCRIPTION
This removes all tracing from `Language.Purus.*` modules, whether via `trace`, `traceM` or the dedicated tracing module. Said module has been left in place for now.