### PR TITLE
Bump plutus-core, add serializer

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,7 +9,6 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
-
 packages:
   purescript.cabal
 
@@ -20,4 +19,4 @@ constraints:
 test-show-details: direct
 
 index-state:
-  , cardano-haskell-packages 2024-06-27T10:04:00Z
+  , cardano-haskell-packages 2024-06-17T12:18:52Z

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "CHaP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1725978043,
+        "narHash": "sha256-3AwgQ308g74rISxUlbzQRX3At0trVoH836vBwkcFFYg=",
+        "owner": "input-output-hk",
+        "repo": "cardano-haskell-packages",
+        "rev": "ce5ba82d474225506523e66a4050718de7e2b3fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
     "HTTP": {
       "flake": false,
       "locked": {
@@ -13,6 +30,23 @@
       "original": {
         "owner": "phadej",
         "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "blst": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1691598027,
+        "narHash": "sha256-oqljy+ZXJAXEB/fJtmB8rlAr4UXM+Z2OkDa20gpILNA=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "3dd0f804b1819e5d03fb22ca2e6fac105932043a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "ref": "v0.3.11",
+        "repo": "blst",
         "type": "github"
       }
     },
@@ -123,34 +157,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1706830856,
-        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -171,43 +187,6 @@
         "type": "github"
       }
     },
-    "ghc98X": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696643148,
-        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
-        "ref": "ghc-9.8",
-        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
-        "revCount": 61642,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.8",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc99": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1701580282,
-        "narHash": "sha256-drA01r3JrXnkKyzI+owMZGxX0JameMzjK0W5jJE/+V4=",
-        "ref": "refs/heads/master",
-        "rev": "f5eb0f2982e9cf27515e892c4bdf634bcfb28459",
-        "revCount": 62197,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -216,11 +195,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703887061,
-        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -232,11 +211,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1708215850,
-        "narHash": "sha256-jaxFHCObJ3uON5RNbeon795RmBG/SUFcFM77TAxx3hg=",
+        "lastModified": 1726014807,
+        "narHash": "sha256-a1Vf++zjoFgSYl8ahl7qOwuQtDgn9bFDhr1T2rxqED4=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "f5c26f4307f80cdc8ba7b762e0738c09d40a4685",
+        "rev": "45251f373aeb0db77d1e3e89e26b3bebd7897dca",
         "type": "github"
       },
       "original": {
@@ -254,8 +233,6 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc98X": "ghc98X",
-        "ghc99": "ghc99",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
@@ -264,10 +241,12 @@
         "hls-2.4": "hls-2.4",
         "hls-2.5": "hls-2.5",
         "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
+        "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
-        "nix-tools-static": "nix-tools-static",
         "nixpkgs": [
           "haskell-nix",
           "nixpkgs-unstable"
@@ -279,16 +258,17 @@
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1708217408,
-        "narHash": "sha256-Ri9PXSAvg25bBvcJOCTsi6pRhaT8Wp37037KMfXYeOU=",
+        "lastModified": 1726015837,
+        "narHash": "sha256-ujrgg3iku0qvG4Q9wjUqSzQd37y0XfRY/R/poUyiv1c=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "2fb6466a23873e590ef96066ee18a75998830c7b",
+        "rev": "1e4b13b277f8a3ba0299ff1152e0f1ce419235fe",
         "type": "github"
       },
       "original": {
@@ -307,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704029560,
-        "narHash": "sha256-a4Iu7x1OP+uSYpqadOu8VCPY+MPF3+f6KIi+MAxlgyw=",
+        "lastModified": 1724947644,
+        "narHash": "sha256-MHHrHasTngp7EYQOObHJ1a/IsRF+wodHqOckhH6uZbk=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "d5cbf433a6ae9cae05400189a8dbc6412a03ba16",
+        "rev": "dba4367b9a9d9615456c430a6d6af716f6e84cef",
         "type": "github"
       },
       "original": {
@@ -439,6 +419,57 @@
         "type": "github"
       }
     },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1718469202,
+        "narHash": "sha256-THXSz+iwB1yQQsr/PY151+2GvtoJnTIB2pIQ4OzfjD4=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "40891bccb235ebacce020b598b083eab9dda80f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hpc-coveralls": {
       "flake": false,
       "locked": {
@@ -478,21 +509,45 @@
         "type": "indirect"
       }
     },
+    "iohk-nix": {
+      "inputs": {
+        "blst": "blst",
+        "nixpkgs": [
+          "haskell-nix",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1",
+        "sodium": "sodium"
+      },
+      "locked": {
+        "lastModified": 1721825987,
+        "narHash": "sha256-PPcma4tjozwXJAWf+YtHUQUulmxwulVlwSQzKItx/n8=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "eb61f2c14e1f610ec59117ad40f8690cddbf80cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1691634696,
-        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
-        "ref": "hkm/remote-iserv",
-        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
-        "revCount": 14,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "lastModified": 1717479972,
+        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "type": "github"
       },
       "original": {
-        "ref": "hkm/remote-iserv",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
       }
     },
     "lowdown-src": {
@@ -529,23 +584,6 @@
         "owner": "NixOS",
         "ref": "2.11.0",
         "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix-tools-static": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1706266250,
-        "narHash": "sha256-9t+GRk3eO9muCtKdNAwBtNBZ5dH1xHcnS17WaQyftwA=",
-        "owner": "input-output-hk",
-        "repo": "haskell-nix-example",
-        "rev": "580cb6db546a7777dad3b9c0fa487a366c045c4e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "nix",
-        "repo": "haskell-nix-example",
         "type": "github"
       }
     },
@@ -647,11 +685,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1701362232,
-        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
@@ -663,16 +701,32 @@
     },
     "nixpkgs-2311": {
       "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1720122915,
+        "narHash": "sha256-Nby8WWxj0elBu1xuRaUcRjPi/rU3xVbkAt2kj4QwX2U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "835cf2d3f37989c5db6585a28de967a667a75fb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -695,27 +749,27 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1694822471,
-        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
+        "lastModified": 1720181791,
+        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
+        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1708276637,
-        "narHash": "sha256-+gICdImzDvxULC/+iqsmLsvwEv5LQuFglxn2fk/VyQM=",
+        "lastModified": 1726101511,
+        "narHash": "sha256-rrqeblElkicFjNwdCQNkR90clsYchZvK3zNLhYEwJAM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ec841889d30aabad381acfa9529fe6045268bdbd",
+        "rev": "0798cdca2d3b571034e1aaa284c7e1fe7217bac1",
         "type": "github"
       },
       "original": {
@@ -744,7 +798,6 @@
     "pre-commit-hooks-nix": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -754,11 +807,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708018599,
-        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
+        "lastModified": 1725513492,
+        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
+        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
         "type": "github"
       },
       "original": {
@@ -769,41 +822,62 @@
     },
     "root": {
       "inputs": {
+        "CHaP": "CHaP",
         "flake-parts": "flake-parts",
         "haskell-nix": "haskell-nix",
         "hci-effects": "hci-effects",
+        "iohk-nix": "iohk-nix",
         "nixpkgs": "nixpkgs_2",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix"
+      }
+    },
+    "secp256k1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "sodium": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
       }
     },
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1708214991,
-        "narHash": "sha256-PCVnVqnBctf/qkpTBnBxwDHvfZaxXeq0bO98LxoKfhY=",
+        "lastModified": 1726013671,
+        "narHash": "sha256-gEv+4fXaibUwYZL0fl9j9vKWuBCikUiellsk1myrU5U=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "0a279134ea4ae6269b93f76638c4ed9ccd9a496a",
+        "rev": "b1c47ac9cfb38c54ab30be9b982f72c93def5117",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,10 @@
     haskell-nix = {
       url = "github:input-output-hk/haskell.nix";
     };
+    CHaP.url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
+    CHaP.flake = false;
+    iohk-nix.url = "github:input-output-hk/iohk-nix";
+    iohk-nix.inputs.nixpkgs.follows = "haskell-nix/nixpkgs";
   };
   outputs = inputs:
     let

--- a/nix/haskell/default.nix
+++ b/nix/haskell/default.nix
@@ -1,6 +1,7 @@
 { self
 , lib
 , flake-parts-lib
+, inputs
 , ...
 }:
 let
@@ -20,7 +21,7 @@ in
       config =
         let
           mkHaskellPackage = pkgs.callPackage ./lib.nix {
-            inherit lib system;
+            inherit lib system inputs;
             haskellNixNixpkgs = self.inputs.haskell-nix.inputs.nixpkgs;
             haskellNixOverlay = self.inputs.haskell-nix.overlay;
           };

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -196,7 +196,7 @@ common defaults
     parallel >=3.2.2.0 && <3.3,
     parsec >=3.1.15.0 && <3.2,
     pattern-arrows >=0.0.2 && <0.1,
-    process ==1.6.13.1,
+    process >= 1.6.13.1 && <2.0,
     prettyprinter ==1.7.1,
     protolude >=0.3.1 && <0.4,
     regex-tdfa >=1.3.1.2 && <1.4,
@@ -218,8 +218,9 @@ common defaults
     utf8-string >=1.0.2 && <1.1,
     vector >=0.12.3.1 && <0.13,
     witherable >=0.4.2 && <0.5,
-    plutus-core,
-    plutus-core:plutus-ir
+    plutus-core ==1.22.0.0,
+    plutus-core:plutus-ir,
+    plutus-ledger-api ==1.22.0.0
 
 library
   import: defaults
@@ -406,7 +407,7 @@ library
 
     Language.Purus.Config
     Language.Purus.Debug
-    Language.Purus.Eval 
+    Language.Purus.Eval
     Language.Purus.IR
     Language.Purus.IR.Utils
     Language.Purus.Make
@@ -418,12 +419,12 @@ library
     Language.Purus.Pipeline.DesugarObjects
     Language.Purus.Pipeline.EliminateCases
     Language.Purus.Pipeline.GenerateDatatypes
-    Language.Purus.Pipeline.GenerateDatatypes.Utils 
+    Language.Purus.Pipeline.GenerateDatatypes.Utils
     Language.Purus.Pipeline.Inline
-    Language.Purus.Pipeline.Inline.Types 
+    Language.Purus.Pipeline.Inline.Types
     Language.Purus.Pipeline.Instantiate
     Language.Purus.Pipeline.Lift
-    Language.Purus.Pipeline.Lift.Types 
+    Language.Purus.Pipeline.Lift.Types
     Language.Purus.Pretty
     Language.Purus.Pretty.Common
     Language.Purus.Pretty.Expr
@@ -512,7 +513,7 @@ test-suite tests
     HUnit >=1.6.2.0 && <1.7,
     newtype >=0.2.2.0 && <0.3,
     QuickCheck >=2.14.2 && <2.15,
-    plutus-core ==1.7.0.0,
+    plutus-core ==1.22.0.0,
     regex-base >=0.94.0.2 && <0.95,
     split >=0.2.3.4 && <0.3,
     typed-process >=0.2.10.1 && <0.3,

--- a/src/Language/PureScript/Constants/Purus.hs
+++ b/src/Language/PureScript/Constants/Purus.hs
@@ -21,6 +21,9 @@ $( ctorBaseNames ''DefaultFun >>= \builtins -> TH.declare $ do
       TH.ty "BuiltinList"
       TH.ty "BuiltinByteString"
       TH.ty "BuiltinUnit"
+      TH.ty "BuiltinElementG1"
+      TH.ty "BuiltinElementG2"
+      TH.ty "BuiltinMlResult"
 
       -- We'll need this sooner or later
       TH.ty "AsData"

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -1059,5 +1059,6 @@ builtinCxt =
     , PLC.I_mkNilData #@ tyUnit -:> tyBuiltinList tyBuiltinData
     , PLC.I_mkNilPairData #@ tyUnit -:> tyBuiltinList (tyBuiltinPair tyBuiltinData tyBuiltinData)
     -- TODO: the Bls12 crypto primfuns
-    -- NOTE: IntegerToByteString & ByteStringToInteger don't appear to be in the version of PlutusCore we have?
+    , PLC.I_integerToByteString #@ tyBoolean -:> tyInt -:> tyInt -:> tyByteString
+    , PLC.I_byteStringToInteger #@ tyBoolean -:> tyByteString -:> tyInt
     ]

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -952,6 +952,15 @@ tyBuiltinList = TypeApp nullSourceAnn (srcTypeConstructor PLC.BuiltinList)
 tyByteString :: SourceType
 tyByteString = srcTypeConstructor PLC.BuiltinByteString
 
+tyElementG1 :: SourceType
+tyElementG1 = srcTypeConstructor PLC.BuiltinElementG1
+
+tyElementG2 :: SourceType
+tyElementG2 = srcTypeConstructor PLC.BuiltinElementG2
+
+tyMlResult :: SourceType
+tyMlResult = srcTypeConstructor PLC.BuiltinMlResult
+
 tyUnit :: SourceType
 tyUnit = srcTypeConstructor C.Unit
 
@@ -971,6 +980,9 @@ builtinTypes =
     , (PLC.BuiltinPair, (kindType -:> kindType -:> kindType, ExternData [Representational, Representational]))
     , (PLC.BuiltinList, (kindType -:> kindType, ExternData [Representational]))
     , (PLC.BuiltinByteString, (kindType, ExternData []))
+    , (PLC.BuiltinElementG1, (kindType, ExternData []))
+    , (PLC.BuiltinElementG2, (kindType, ExternData []))
+    , (PLC.BuiltinMlResult, (kindType, ExternData []))
     ]
 
 primFunctions :: M.Map (Qualified Ident) (SourceType, NameKind, NameVisibility)
@@ -1058,7 +1070,28 @@ builtinCxt =
       PLC.I_mkPairData #@ tyBuiltinData -:> tyBuiltinData -:> tyBuiltinPair tyBuiltinData tyBuiltinData
     , PLC.I_mkNilData #@ tyUnit -:> tyBuiltinList tyBuiltinData
     , PLC.I_mkNilPairData #@ tyUnit -:> tyBuiltinList (tyBuiltinPair tyBuiltinData tyBuiltinData)
-    -- TODO: the Bls12 crypto primfuns
-    , PLC.I_integerToByteString #@ tyBoolean -:> tyInt -:> tyInt -:> tyByteString
+    , -- BLS primitives
+      PLC.I_bls12_381_G1_add #@ tyElementG1 -:> tyElementG1 -:> tyElementG1
+    , PLC.I_bls12_381_G1_neg #@ tyElementG1 -:> tyElementG1
+    , PLC.I_bls12_381_G1_scalarMul #@ tyInt -:> tyElementG1 -:> tyElementG1
+    , PLC.I_bls12_381_G1_compress #@ tyElementG1 -:> tyByteString
+    , PLC.I_bls12_381_G1_uncompress #@ tyByteString -:> tyElementG1
+    , PLC.I_bls12_381_G1_hashToGroup #@ tyByteString -:> tyByteString -:> tyElementG1
+    , PLC.I_bls12_381_G1_equal #@ tyElementG1 -:> tyElementG1 -:> tyBoolean
+    , PLC.I_bls12_381_G2_add #@ tyElementG2 -:> tyElementG2 -:> tyElementG2
+    , PLC.I_bls12_381_G2_neg #@ tyElementG2 -:> tyElementG2
+    , PLC.I_bls12_381_G2_scalarMul #@ tyInt -:> tyElementG2 -:> tyElementG2
+    , PLC.I_bls12_381_G2_compress #@ tyElementG2 -:> tyByteString
+    , PLC.I_bls12_381_G2_uncompress #@ tyByteString -:> tyElementG2
+    , PLC.I_bls12_381_G2_hashToGroup #@ tyByteString -:> tyByteString -:> tyElementG2
+    , PLC.I_bls12_381_G2_equal #@ tyElementG2 -:> tyElementG2 -:> tyBoolean
+    , PLC.I_bls12_381_millerLoop #@ tyElementG1 -:> tyElementG2 -:> tyMlResult
+    , PLC.I_bls12_381_mulMlResult #@ tyMlResult -:> tyMlResult -:> tyMlResult
+    , PLC.I_bls12_381_finalVerify #@ tyMlResult -:> tyMlResult -:> tyBoolean
+    , -- More hashes
+      PLC.I_keccak_256 #@ tyByteString -:> tyByteString
+    , PLC.I_blake2b_224 #@ tyByteString -:> tyByteString
+    , -- Conversion
+      PLC.I_integerToByteString #@ tyBoolean -:> tyInt -:> tyInt -:> tyByteString
     , PLC.I_byteStringToInteger #@ tyBoolean -:> tyByteString -:> tyInt
     ]

--- a/src/Language/Purus/Pipeline/CompileToPIR/Utils.hs
+++ b/src/Language/Purus/Pipeline/CompileToPIR/Utils.hs
@@ -151,6 +151,8 @@ builtinSubstitutions =
     , (PLC.EqualsData, pirEqualsData)
     , (PLC.IfThenElse, pirIfThenElse)
     , (PLC.NullList, pirNullList)
+    , (PLC.IntegerToByteString, pirI2BS)
+    , (PLC.ByteStringToInteger, pirBS2I)
     ]
 
 tyInt, tyBool, tyByteString, tyData, tyString :: Ty
@@ -238,3 +240,19 @@ pirNullList =
     freshLam' listAppliedTy $ \_ arg -> do
       let nullListFun = PIR.Builtin () PLC.NullList
       pirBoolToBoolean (pirTyInst tv nullListFun # arg)
+
+-- Bool -> Int -> Int -> ByteString
+pirI2BS :: PlutusContext PIRTerm
+pirI2BS = 
+  freshLam tyBool $ \_ b -> do
+    b' <- pirBoolToBoolean b
+    let fun = PIR.Builtin () PLC.IntegerToByteString
+    pure $ fun # b'
+
+-- Bool -> ByteString -> Int
+pirBS2I :: PlutusContext PIRTerm
+pirBS2I = 
+  freshLam tyBool $ \_ b -> do
+    b' <- pirBoolToBoolean b
+    let fun = PIR.Builtin () PLC.ByteStringToInteger
+    pure $ fun # b'

--- a/src/Language/Purus/Pipeline/GenerateDatatypes.hs
+++ b/src/Language/Purus/Pipeline/GenerateDatatypes.hs
@@ -217,6 +217,9 @@ handleBuiltinTy = \case
   C.BuiltinPair -> pure $ TyBuiltin () (PLC.SomeTypeIn PLC.DefaultUniProtoPair)
   C.BuiltinList -> pure $ TyBuiltin () (PLC.SomeTypeIn PLC.DefaultUniProtoList)
   C.BuiltinByteString -> pure $ TyBuiltin () (PLC.SomeTypeIn PLC.DefaultUniByteString)
+  C.BuiltinElementG1 -> pure $ TyBuiltin () (PLC.SomeTypeIn PLC.DefaultUniBLS12_381_G1_Element)
+  C.BuiltinElementG2 -> pure $ TyBuiltin () (PLC.SomeTypeIn PLC.DefaultUniBLS12_381_G2_Element)
+  C.BuiltinMlResult -> pure $ TyBuiltin () (PLC.SomeTypeIn PLC.DefaultUniBLS12_381_MlResult)
   other -> Left $ "Error when translating to PIR types: unsupported builtin type: " <> show other
 
 handlePrimTy :: Qualified (ProperName 'TypeName) -> Maybe (PLC.Type tyname PLC.DefaultUni ())


### PR DESCRIPTION
This adds a serialization method for UPLC, as well as bumping `plutus-core` to a more recent version. The functionality we require needs a `plutus-ledger-api` dependency: this is subpar, but we can't avoid this, as the functionality we need resides there. We could eliminate it by bumping `plutus-core` to a higher version than current, but that would cause even more breakage.