### PR TITLE
Add the test suite to `checks`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -24,6 +24,8 @@
         purs = purus.packages."purescript:exe:purs";
       };
 
+      inherit (purus) checks;
+
       apps = {
         purs.program = "${self'.packages.purs}/bin/purs";
       };


### PR DESCRIPTION
This PR:
- [x] Adds the Haskell test-suite `tests` to the `checks` attribute s.t. it runs automatically on CI.
  Evidence of completion: we can see the test suite running [here](https://hercules-ci.com/accounts/github/mlabs-haskell/derivations/%2Fnix%2Fstore%2F65q6d3bvgrx8azgp91lx5imy7s2fca4y-purescript-test-tests-0.15.13-check.drv/log?via-job=09812b8d-f167-430a-9353-7512cf4029c9) by manually staring at the log output

Notes:
- It looks like this project (like most projects) use haskell.nix which surprisingly somewhat documents where it hides the test executables in this page: https://input-output-hk.github.io/haskell.nix/tutorials/getting-started-flakes.html?highlight=.flake#getting-started-with-flakes
- Specific to this project, it's somewhat interesting that this mashes together both `callPackage` style attribute sets (this is where some "generic" Haskell compilation stuff is defined in e.g. `./nix/haskell`) along with nix modules. 